### PR TITLE
feat: ajouter backend SQLite + API REST pour likes/commentaires

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,107 @@
+# Backend DB (likes + commentaires)
+
+Ce backend ajoute une base SQLite + API REST pour stocker et afficher les likes/commentaires des utilisateurs.
+
+## 1) Installation
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+API disponible sur `http://localhost:4000`.
+
+## 2) Base de données
+
+Le schéma est dans `backend/schema.sql`:
+- `users`
+- `beats`
+- `beat_likes`
+- `beat_comments`
+
+Le fichier SQLite est créé automatiquement: `backend/danybeats.db`.
+
+## 3) Endpoints utiles
+
+### Health
+```http
+GET /api/health
+```
+
+### Statistiques d'un beat
+```http
+GET /api/beats/:beatRef/stats
+```
+`beatRef` peut être un id (`12`) ou un slug (`trap-01`).
+
+### Like / Unlike
+```http
+POST /api/beats/:beatRef/likes
+Content-Type: application/json
+
+{
+  "sessionId": "browser-uuid",
+  "liked": true
+}
+```
+
+### Lister les commentaires
+```http
+GET /api/beats/:beatRef/comments?limit=20&offset=0
+```
+
+### Ajouter un commentaire
+```http
+POST /api/beats/:beatRef/comments
+Content-Type: application/json
+
+{
+  "sessionId": "browser-uuid",
+  "authorName": "Dany Fan",
+  "text": "Le beat est trop lourd 🔥"
+}
+```
+
+### Vue admin (stats globales)
+```http
+GET /api/admin/overview
+```
+
+## 4) Exemple d'intégration front (`index.html`)
+
+```js
+const API_BASE = 'http://localhost:4000/api';
+
+async function loadBeatStats(beatId) {
+  const res = await fetch(`${API_BASE}/beats/${beatId}/stats`);
+  const data = await res.json();
+  document.getElementById(`like-count-${beatId}`).textContent = data.likes;
+  document.getElementById(`comment-count-${beatId}`).textContent = data.comments;
+}
+
+async function likeBeat(beatId, sessionId, liked) {
+  const res = await fetch(`${API_BASE}/beats/${beatId}/likes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId, liked })
+  });
+  return res.json();
+}
+
+async function addComment(beatId, sessionId, authorName, text) {
+  const res = await fetch(`${API_BASE}/beats/${beatId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId, authorName, text })
+  });
+  return res.json();
+}
+```
+
+## 5) Conseils production
+
+- Mettre Nginx/Apache devant l'API.
+- Ajouter authentification (JWT/session serveur) pour sécuriser les actions.
+- Ajouter rate-limit anti-spam sur les commentaires.
+- Prévoir modération (`status: pending/approved/rejected`) dans `beat_comments`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dany-beats-backend",
+  "version": "1.0.0",
+  "description": "API likes/commentaires avec SQLite pour DANY BEATS",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js",
+    "check": "node --check server.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.8.1",
+    "cors": "^2.8.5",
+    "express": "^4.21.2"
+  }
+}

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,54 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL UNIQUE,
+  email TEXT UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS beats (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS beat_likes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  beat_id INTEGER NOT NULL,
+  user_id INTEGER,
+  session_id TEXT,
+  is_liked INTEGER NOT NULL DEFAULT 1 CHECK (is_liked IN (0, 1)),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (beat_id) REFERENCES beats(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  CHECK (user_id IS NOT NULL OR session_id IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_like_user
+ON beat_likes(beat_id, user_id)
+WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_like_session
+ON beat_likes(beat_id, session_id)
+WHERE session_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_likes_beat_id ON beat_likes(beat_id);
+
+CREATE TABLE IF NOT EXISTS beat_comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  beat_id INTEGER NOT NULL,
+  user_id INTEGER,
+  session_id TEXT,
+  author_name TEXT NOT NULL,
+  comment_text TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (beat_id) REFERENCES beats(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  CHECK (length(trim(comment_text)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_comments_beat_id_created_at
+ON beat_comments(beat_id, created_at DESC);

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,196 @@
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+const cors = require('cors');
+const Database = require('better-sqlite3');
+
+const PORT = process.env.PORT || 4000;
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'danybeats.db');
+const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+
+function initDatabase() {
+  const schema = fs.readFileSync(SCHEMA_PATH, 'utf8');
+  db.exec(schema);
+}
+
+initDatabase();
+
+const insertBeatStmt = db.prepare(
+  'INSERT INTO beats (slug, title) VALUES (?, ?) ON CONFLICT(slug) DO NOTHING'
+);
+const getBeatBySlugStmt = db.prepare('SELECT id, slug, title FROM beats WHERE slug = ?');
+const getBeatByIdStmt = db.prepare('SELECT id, slug, title FROM beats WHERE id = ?');
+
+function resolveBeatId(beatRef) {
+  if (/^\d+$/.test(beatRef)) {
+    const beat = getBeatByIdStmt.get(Number(beatRef));
+    return beat ? beat.id : null;
+  }
+
+  insertBeatStmt.run(beatRef, beatRef.replaceAll('-', ' '));
+  const beat = getBeatBySlugStmt.get(beatRef);
+  return beat ? beat.id : null;
+}
+
+function getLikesCount(beatId) {
+  const row = db
+    .prepare('SELECT COUNT(*) AS total FROM beat_likes WHERE beat_id = ? AND is_liked = 1')
+    .get(beatId);
+  return row.total;
+}
+
+function getCommentsCount(beatId) {
+  const row = db.prepare('SELECT COUNT(*) AS total FROM beat_comments WHERE beat_id = ?').get(beatId);
+  return row.total;
+}
+
+app.get('/api/health', (req, res) => {
+  res.json({ ok: true, dbPath: DB_PATH });
+});
+
+app.get('/api/beats/:beatRef/stats', (req, res) => {
+  const beatId = resolveBeatId(req.params.beatRef);
+  if (!beatId) {
+    return res.status(404).json({ error: 'Beat introuvable' });
+  }
+
+  return res.json({
+    beatId,
+    likes: getLikesCount(beatId),
+    comments: getCommentsCount(beatId)
+  });
+});
+
+app.post('/api/beats/:beatRef/likes', (req, res) => {
+  const beatId = resolveBeatId(req.params.beatRef);
+  if (!beatId) {
+    return res.status(404).json({ error: 'Beat introuvable' });
+  }
+
+  const { userId, sessionId, liked } = req.body;
+
+  if (!userId && !sessionId) {
+    return res.status(400).json({ error: 'userId ou sessionId est obligatoire' });
+  }
+
+  if (typeof liked !== 'boolean') {
+    return res.status(400).json({ error: 'liked doit être true ou false' });
+  }
+
+  const existing = db
+    .prepare(
+      `SELECT id FROM beat_likes
+       WHERE beat_id = ?
+       AND ((user_id = ? AND ? IS NOT NULL) OR (session_id = ? AND ? IS NOT NULL))`
+    )
+    .get(beatId, userId || null, userId || null, sessionId || null, sessionId || null);
+
+  if (existing) {
+    db.prepare(
+      `UPDATE beat_likes
+       SET is_liked = ?, updated_at = datetime('now')
+       WHERE id = ?`
+    ).run(liked ? 1 : 0, existing.id);
+  } else {
+    db.prepare(
+      `INSERT INTO beat_likes (beat_id, user_id, session_id, is_liked)
+       VALUES (?, ?, ?, ?)`
+    ).run(beatId, userId || null, sessionId || null, liked ? 1 : 0);
+  }
+
+  return res.json({
+    beatId,
+    liked,
+    likes: getLikesCount(beatId)
+  });
+});
+
+app.get('/api/beats/:beatRef/comments', (req, res) => {
+  const beatId = resolveBeatId(req.params.beatRef);
+  if (!beatId) {
+    return res.status(404).json({ error: 'Beat introuvable' });
+  }
+
+  const limit = Math.min(Number(req.query.limit) || 50, 100);
+  const offset = Math.max(Number(req.query.offset) || 0, 0);
+
+  const comments = db
+    .prepare(
+      `SELECT id, beat_id AS beatId, author_name AS authorName, comment_text AS text, created_at AS createdAt
+       FROM beat_comments
+       WHERE beat_id = ?
+       ORDER BY id DESC
+       LIMIT ? OFFSET ?`
+    )
+    .all(beatId, limit, offset);
+
+  return res.json({
+    beatId,
+    total: getCommentsCount(beatId),
+    comments
+  });
+});
+
+app.post('/api/beats/:beatRef/comments', (req, res) => {
+  const beatId = resolveBeatId(req.params.beatRef);
+  if (!beatId) {
+    return res.status(404).json({ error: 'Beat introuvable' });
+  }
+
+  const { userId, sessionId, authorName, text } = req.body;
+
+  if (!authorName || !String(authorName).trim()) {
+    return res.status(400).json({ error: 'authorName est obligatoire' });
+  }
+
+  if (!text || !String(text).trim()) {
+    return res.status(400).json({ error: 'text est obligatoire' });
+  }
+
+  db.prepare(
+    `INSERT INTO beat_comments (beat_id, user_id, session_id, author_name, comment_text)
+     VALUES (?, ?, ?, ?, ?)`
+  ).run(beatId, userId || null, sessionId || null, String(authorName).trim(), String(text).trim());
+
+  return res.status(201).json({
+    beatId,
+    comments: getCommentsCount(beatId)
+  });
+});
+
+app.get('/api/admin/overview', (req, res) => {
+  const beats = db
+    .prepare(
+      `SELECT b.id, b.slug, b.title,
+              SUM(CASE WHEN l.is_liked = 1 THEN 1 ELSE 0 END) AS likes,
+              COUNT(DISTINCT c.id) AS comments
+       FROM beats b
+       LEFT JOIN beat_likes l ON l.beat_id = b.id
+       LEFT JOIN beat_comments c ON c.beat_id = b.id
+       GROUP BY b.id
+       ORDER BY likes DESC, comments DESC, b.id DESC`
+    )
+    .all();
+
+  const totals = db
+    .prepare(
+      `SELECT
+        (SELECT COUNT(*) FROM beat_likes WHERE is_liked = 1) AS totalLikes,
+        (SELECT COUNT(*) FROM beat_comments) AS totalComments,
+        (SELECT COUNT(*) FROM beats) AS totalBeats`
+    )
+    .get();
+
+  res.json({ totals, beats });
+});
+
+app.listen(PORT, () => {
+  console.log(`✅ API DANY BEATS lancée sur http://localhost:${PORT}`);
+});

--- a/index.html
+++ b/index.html
@@ -2775,26 +2775,71 @@ nav.secret-mode {
     </footer>
 <script>
 // ========== BEAT LIKE SYSTEM ==========
+const API_BASE = window.DANYBEATS_API_BASE || 'http://localhost:4000/api';
+const SESSION_KEY = 'danybeats_session_id';
 let beatLikes = JSON.parse(localStorage.getItem('danybeats_beat_likes')) || {};
+let beatComments = JSON.parse(localStorage.getItem('danybeats_beat_comments')) || {};
 
-function toggleLikeBeat(beatId) {
+function getSessionId() {
+    let sessionId = localStorage.getItem(SESSION_KEY);
+    if (!sessionId) {
+        sessionId = `guest-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        localStorage.setItem(SESSION_KEY, sessionId);
+    }
+    return sessionId;
+}
+
+function escapeHtml(text) {
+    return String(text)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+}
+
+function mapServerComment(comment) {
+    return {
+        name: comment.authorName,
+        text: comment.text,
+        date: new Date(comment.createdAt).toLocaleString('fr-FR')
+    };
+}
+
+async function fetchJson(url, options) {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+        throw new Error(`Erreur API: ${response.status}`);
+    }
+    return response.json();
+}
+
+async function toggleLikeBeat(beatId) {
     const likeBtn = document.getElementById('like-btn-' + beatId);
     const likeCount = document.getElementById('like-count-' + beatId);
-    
+
     if (!beatLikes[beatId]) {
         beatLikes[beatId] = { count: 0, liked: false };
     }
-    
-    if (beatLikes[beatId].liked) {
-        beatLikes[beatId].count--;
-        beatLikes[beatId].liked = false;
-        likeBtn.classList.remove('liked');
-    } else {
-        beatLikes[beatId].count++;
-        beatLikes[beatId].liked = true;
-        likeBtn.classList.add('liked');
+
+    const nextLiked = !beatLikes[beatId].liked;
+
+    try {
+        const payload = await fetchJson(`${API_BASE}/beats/${beatId}/likes`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessionId: getSessionId(), liked: nextLiked })
+        });
+
+        beatLikes[beatId].liked = payload.liked;
+        beatLikes[beatId].count = payload.likes;
+    } catch (error) {
+        console.warn('API likes indisponible, fallback localStorage:', error.message);
+        beatLikes[beatId].liked = nextLiked;
+        beatLikes[beatId].count = Math.max(0, (beatLikes[beatId].count || 0) + (nextLiked ? 1 : -1));
     }
-    
+
+    likeBtn.classList.toggle('liked', beatLikes[beatId].liked);
     likeCount.textContent = beatLikes[beatId].count;
     localStorage.setItem('danybeats_beat_likes', JSON.stringify(beatLikes));
 }
@@ -2826,7 +2871,6 @@ function closeMenu() {
 // ========== COMMENT MODAL SYSTEM ==========
 let currentBeatId = null;
 let currentBeatName = '';
-let beatComments = JSON.parse(localStorage.getItem('danybeats_beat_comments')) || {};
 
 function openCommentModal(beatId, beatName) {
     currentBeatId = beatId;
@@ -2844,15 +2888,15 @@ function closeCommentModal() {
     document.getElementById('modalUserComment').value = '';
 }
 
-function submitBeatComment() {
+async function submitBeatComment() {
     const userName = document.getElementById('modalUserName').value.trim();
     const userComment = document.getElementById('modalUserComment').value.trim();
-    
+
     if (!userName || !userComment) {
         alert('⚠️ Veuillez remplir tous les champs!');
         return;
     }
-    
+
     const comment = {
         name: userName,
         text: userComment,
@@ -2860,55 +2904,129 @@ function submitBeatComment() {
         beatId: currentBeatId,
         beatName: currentBeatName
     };
-    
+
     if (!beatComments[currentBeatId]) {
         beatComments[currentBeatId] = [];
     }
-    
-    beatComments[currentBeatId].unshift(comment);
-    localStorage.setItem('danybeats_beat_comments', JSON.stringify(beatComments));
-    
+
+    try {
+        await fetchJson(`${API_BASE}/beats/${currentBeatId}/comments`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                sessionId: getSessionId(),
+                authorName: userName,
+                text: userComment
+            })
+        });
+        await loadBeatComments(currentBeatId);
+    } catch (error) {
+        console.warn('API commentaires indisponible, fallback localStorage:', error.message);
+        beatComments[currentBeatId].unshift(comment);
+        localStorage.setItem('danybeats_beat_comments', JSON.stringify(beatComments));
+        renderBeatComments(beatComments[currentBeatId]);
+    }
+
     sendBeatCommentEmail(comment);
-    loadBeatComments(currentBeatId);
-    updateCommentCount(currentBeatId);
-    
+    await updateCommentCount(currentBeatId);
+
     document.getElementById('modalUserName').value = '';
     document.getElementById('modalUserComment').value = '';
-    
+
     alert('✅ Merci! Votre commentaire a été ajouté!');
 }
 
-function loadBeatComments(beatId) {
+function renderBeatComments(comments) {
     const commentsList = document.getElementById('beatCommentsList');
-    const comments = beatComments[beatId] || [];
-    
-    if (comments.length === 0) {
+
+    if (!comments || comments.length === 0) {
         commentsList.innerHTML = '<p style="opacity: 0.6; text-align: center;">Aucun commentaire. Soyez le premier!</p>';
         return;
     }
-    
+
     commentsList.innerHTML = comments.map(comment => `
         <div class="beat-comment-item">
             <div class="beat-comment-header">
-                <span class="beat-comment-author">👤 ${comment.name}</span>
-                <span class="beat-comment-date">${comment.date}</span>
+                <span class="beat-comment-author">👤 ${escapeHtml(comment.name)}</span>
+                <span class="beat-comment-date">${escapeHtml(comment.date)}</span>
             </div>
-            <div class="beat-comment-text">${comment.text}</div>
+            <div class="beat-comment-text">${escapeHtml(comment.text)}</div>
         </div>
     `).join('');
 }
 
-function updateCommentCount(beatId) {
+async function loadBeatComments(beatId) {
+    try {
+        const payload = await fetchJson(`${API_BASE}/beats/${beatId}/comments?limit=50&offset=0`);
+        beatComments[beatId] = payload.comments.map(mapServerComment);
+        localStorage.setItem('danybeats_beat_comments', JSON.stringify(beatComments));
+    } catch (error) {
+        console.warn('API commentaires indisponible, lecture locale:', error.message);
+        beatComments[beatId] = beatComments[beatId] || [];
+    }
+
+    renderBeatComments(beatComments[beatId]);
+}
+
+async function updateCommentCount(beatId) {
     const countEl = document.getElementById('comment-count-' + beatId);
-    if (countEl && beatComments[beatId]) {
-        countEl.textContent = beatComments[beatId].length;
+    if (!countEl) {
+        return;
+    }
+
+    try {
+        const payload = await fetchJson(`${API_BASE}/beats/${beatId}/stats`);
+        countEl.textContent = payload.comments;
+
+        if (!beatLikes[beatId]) {
+            beatLikes[beatId] = { count: payload.likes, liked: false };
+        } else {
+            beatLikes[beatId].count = payload.likes;
+        }
+
+        const likeCountEl = document.getElementById('like-count-' + beatId);
+        if (likeCountEl) {
+            likeCountEl.textContent = payload.likes;
+        }
+    } catch (error) {
+        countEl.textContent = (beatComments[beatId] || []).length;
     }
 }
 
-function loadAllCommentCounts() {
-    Object.keys(beatComments).forEach(beatId => {
-        updateCommentCount(beatId);
-    });
+async function loadAllCommentCounts() {
+    const likeCountNodes = document.querySelectorAll('[id^="like-count-"]');
+
+    await Promise.all(Array.from(likeCountNodes).map(async node => {
+        const beatId = node.id.replace('like-count-', '');
+        const likeBtn = document.getElementById('like-btn-' + beatId);
+
+        if (!beatLikes[beatId]) {
+            beatLikes[beatId] = { count: 0, liked: false };
+        }
+
+        try {
+            const payload = await fetchJson(`${API_BASE}/beats/${beatId}/stats`);
+            beatLikes[beatId].count = payload.likes;
+            node.textContent = payload.likes;
+
+            const commentEl = document.getElementById('comment-count-' + beatId);
+            if (commentEl) {
+                commentEl.textContent = payload.comments;
+            }
+        } catch (error) {
+            node.textContent = beatLikes[beatId].count || 0;
+            const commentEl = document.getElementById('comment-count-' + beatId);
+            if (commentEl) {
+                commentEl.textContent = (beatComments[beatId] || []).length;
+            }
+        }
+
+        if (likeBtn) {
+            likeBtn.classList.toggle('liked', !!beatLikes[beatId].liked);
+        }
+    }));
+
+    localStorage.setItem('danybeats_beat_likes', JSON.stringify(beatLikes));
 }
 
 function sendBeatCommentEmail(comment) {
@@ -3157,22 +3275,9 @@ function stopAllBeats() {
 }
 
 // ========== EVENT LISTENERS ==========
-window.addEventListener('DOMContentLoaded', function() {
-    // Load likes
-    Object.keys(beatLikes).forEach(beatId => {
-        const likeCount = document.getElementById('like-count-' + beatId);
-        const likeBtn = document.getElementById('like-btn-' + beatId);
-        if (likeCount) {
-            likeCount.textContent = beatLikes[beatId].count;
-            if (beatLikes[beatId].liked) {
-                likeBtn.classList.add('liked');
-            }
-        }
-    });
-    
-    // Load comment counts
-    loadAllCommentCounts();
-    
+window.addEventListener('DOMContentLoaded', async function() {
+    await loadAllCommentCounts();
+
     // Load general comments
     displayComments();
     


### PR DESCRIPTION
### Motivation

- Le site stockait les likes et commentaires côté client (localStorage), ce qui empêche la persistance, la modération et l'analyse centralisée.
- L'objectif est d'ajouter une API légère et une base de données locale pour rendre les likes/commentaires persistants et faciles à consommer depuis le frontend.

### Description

- Ajout d'un backend Node.js/Express dans `backend/` avec `server.js` qui initialise automatiquement une base SQLite via `schema.sql` et expose les endpoints REST.
- Nouveau schéma SQL `backend/schema.sql` avec les tables `users`, `beats`, `beat_likes` et `beat_comments`, contraintes FK, checks et index pour unicité et performances.
- Endpoints implémentés : `GET /api/health`, `GET /api/beats/:beatRef/stats`, `POST /api/beats/:beatRef/likes`, `GET /api/beats/:beatRef/comments`, `POST /api/beats/:beatRef/comments`, et `GET /api/admin/overview` pour une vue globale.
- Ajout de `backend/package.json` (dépendances déclarées) et de `backend/README.md` avec instructions d'installation, exemples d'appels et snippets d'intégration frontend.

### Testing

- `node --check backend/server.js` a été exécuté et a réussi (vérification syntaxique de `server.js`).
- Le schéma a été appliqué avec `sqlite3 /tmp/danybeats_test.db < backend/schema.sql` et la commande `sqlite3 /tmp/danybeats_test.db ".tables"` a confirmé la création des tables (succès).
- `npm install` dans `backend` a échoué dans cet environnement avec une erreur `403 Forbidden` sur le registre npm, donc les dépendances n'ont pas été téléchargées ici (problème d'environnement, pas du code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a044aad8c83259211d13faa2a8ea3)