### PR TITLE
Add bulk beats download endpoint and homepage download button

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { spawn } = require('child_process');
 const express = require('express');
 const cors = require('cors');
 const Database = require('better-sqlite3');
@@ -7,6 +8,7 @@ const Database = require('better-sqlite3');
 const PORT = process.env.PORT || 4000;
 const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'danybeats.db');
 const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
+const MUSIC_DIR = path.resolve(__dirname, '..', 'music');
 
 const app = express();
 app.use(cors());
@@ -189,6 +191,37 @@ app.get('/api/admin/overview', (req, res) => {
     .get();
 
   res.json({ totals, beats });
+});
+
+app.get('/api/beats/download-all', (req, res) => {
+  if (!fs.existsSync(MUSIC_DIR)) {
+    return res.status(404).json({ error: 'Dossier music introuvable' });
+  }
+
+  res.setHeader('Content-Type', 'application/gzip');
+  res.setHeader('Content-Disposition', 'attachment; filename="dany-beats-all.tar.gz"');
+
+  const tarProcess = spawn('tar', ['-czf', '-', '-C', path.dirname(MUSIC_DIR), path.basename(MUSIC_DIR)]);
+
+  tarProcess.stdout.pipe(res);
+
+  tarProcess.on('error', (error) => {
+    if (!res.headersSent) {
+      return res.status(500).json({ error: `Impossible de générer l'archive: ${error.message}` });
+    }
+
+    res.end();
+  });
+
+  tarProcess.stderr.on('data', (chunk) => {
+    console.error(`[download-all] tar stderr: ${chunk.toString()}`);
+  });
+
+  tarProcess.on('close', (code) => {
+    if (code !== 0 && !res.writableEnded) {
+      res.status(500).end();
+    }
+  });
 });
 
 app.listen(PORT, () => {

--- a/index.html
+++ b/index.html
@@ -1154,6 +1154,10 @@ nav.secret-mode {
         <span class="btn-icon">▶</span>
         <span class="btn-text">Jouer Tous Les Beats</span>
     </button>
+    <button class="play-all-homepage-btn" id="downloadAllBeatsBtn" onclick="downloadAllBeats()" style="margin-left: 12px;">
+        <span class="btn-icon">⬇️</span>
+        <span class="btn-text">Télécharger toutes les beats</span>
+    </button>
 </div>
     <section id="beats">
        <div class="beat-item" data-beat-id="1">
@@ -3272,6 +3276,16 @@ function stopAllBeats() {
     });
     currentPlayingIndex = 0;
     isPlayingAll = false;
+}
+
+function downloadAllBeats() {
+    const downloadUrl = `${API_BASE}/beats/download-all`;
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = 'dany-beats-all.tar.gz';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
 }
 
 // ========== EVENT LISTENERS ==========


### PR DESCRIPTION
### Motivation
- Provide a simple way for visitors to download the entire `music/` folder as a single archive from the site. 
- Ensure likes and comments are persisted/shared through the existing backend API so interactions are visible across devices.

### Description
- Added `MUSIC_DIR` and a new backend route `GET /api/beats/download-all` that spawns `tar -czf -` and streams a `dany-beats-all.tar.gz` archive to the client with appropriate headers in `backend/server.js`.
- Added a homepage button labeled “Télécharger toutes les beats” and a `downloadAllBeats()` function in `index.html` which triggers a download from `${API_BASE}/beats/download-all`.
- Kept existing likes/comments endpoints and DB logic unchanged so interaction state continues to be stored in the shared SQLite DB (`backend/server.js` and existing frontend calls to `API_BASE`).

### Testing
- Ran `node --check backend/server.js` and the check completed successfully.
- Ran `npm run check` in `backend/` and it completed successfully.
- Started the backend and requested `GET /api/beats/download-all` via `curl`, verifying `Content-Type` and `Content-Disposition` headers and that the endpoint returned `200 OK`.
- Opened the homepage via a local HTTP server and captured a Playwright screenshot showing the new download button; the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab715e751483258e4a22342754e324)