### PR TITLE
Add live polling to keep likes/comments synchronized across devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -2814,8 +2814,10 @@ nav.secret-mode {
 // ========== BEAT LIKE SYSTEM ==========
 const API_BASE = window.DANYBEATS_API_BASE || 'http://localhost:4000/api';
 const SESSION_KEY = 'danybeats_session_id';
+const LIVE_SYNC_INTERVAL_MS = 15000;
 let beatLikes = JSON.parse(localStorage.getItem('danybeats_beat_likes')) || {};
 let beatComments = JSON.parse(localStorage.getItem('danybeats_beat_comments')) || {};
+let liveSyncTimer = null;
 
 function getSessionId() {
     let sessionId = localStorage.getItem(SESSION_KEY);
@@ -3084,6 +3086,21 @@ async function loadAllCommentCounts() {
     }));
 
     localStorage.setItem('danybeats_beat_likes', JSON.stringify(beatLikes));
+}
+
+function startLiveSync() {
+    if (liveSyncTimer) {
+        clearInterval(liveSyncTimer);
+    }
+
+    liveSyncTimer = setInterval(async () => {
+        await loadAllCommentCounts();
+
+        const modal = document.getElementById('commentModal');
+        if (modal && modal.classList.contains('show') && currentBeatId) {
+            await loadBeatComments(currentBeatId);
+        }
+    }, LIVE_SYNC_INTERVAL_MS);
 }
 
 function sendBeatCommentEmail(comment) {
@@ -3405,6 +3422,7 @@ async function downloadAllBeats() {
 // ========== EVENT LISTENERS ==========
 window.addEventListener('DOMContentLoaded', async function() {
     await loadAllCommentCounts();
+    startLiveSync();
 
     // Load general comments
     displayComments();
@@ -3492,4 +3510,3 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
 </div>
 </body>
 </html>
-


### PR DESCRIPTION
### Motivation
- Ensure likes and comment counts made by one user/device propagate to other open pages without requiring manual refresh.
- Keep the beat comment list in the comment modal updated when new comments arrive elsewhere.

### Description
- Added a 15s live-sync mechanism by introducing `LIVE_SYNC_INTERVAL_MS` and `liveSyncTimer` in `index.html`.
- Implemented `startLiveSync()` which periodically calls `loadAllCommentCounts()` and, when the comment modal is open, `loadBeatComments(currentBeatId)` to refresh counts and comments.
- Start the live sync on `DOMContentLoaded` after the initial `loadAllCommentCounts()` run.
- Only `index.html` was modified to add the polling logic and related state.

### Testing
- Verified the change via `git diff` showing only `index.html` was updated and committed successfully with `git commit` (succeeded).
- Inspected file contents with `nl` and other repo commands to confirm the new constants and `startLiveSync()` are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab74f04684832593694ceef18dcd49)